### PR TITLE
Fix whitespace, tabs, and newlines

### DIFF
--- a/Rtc_Pcf8563.cpp
+++ b/Rtc_Pcf8563.cpp
@@ -16,7 +16,8 @@
  *    28/02/2012 A. Pasotti
  *             fixed a bug in RTCC_ALARM_AF,
  *             added a few (not really useful) methods
-
+ *    22/10/2014 Fix whitespace, tabs, and newlines, cevich
+ *
  *  TODO
  *    x Add Euro date format
  *    Add short time (hh:mm) format
@@ -39,59 +40,57 @@ Rtc_Pcf8563::Rtc_Pcf8563(void)
 
 void Rtc_Pcf8563::initClock()
 {
-  Wire.beginTransmission(Rtcc_Addr);    // Issue I2C start signal
-  Wire.write((byte)0x0);        // start address
+    Wire.beginTransmission(Rtcc_Addr);    // Issue I2C start signal
+    Wire.write((byte)0x0);        // start address
 
-  Wire.write((byte)0x0);     //control/status1
-  Wire.write((byte)0x0);     //control/status2
-  Wire.write((byte)0x01);     //set seconds
-  Wire.write((byte)0x01);    //set minutes
-  Wire.write((byte)0x01);    //set hour
-  Wire.write((byte)0x01);    //set day
-  Wire.write((byte)0x01);    //set weekday
-  Wire.write((byte)0x01);     //set month, century to 1
-  Wire.write((byte)0x01);    //set year to 99
-  Wire.write((byte)0x80);    //minute alarm value reset to 00
-  Wire.write((byte)0x80);    //hour alarm value reset to 00
-  Wire.write((byte)0x80);    //day alarm value reset to 00
-  Wire.write((byte)0x80);    //weekday alarm value reset to 00
-  Wire.write((byte)0x0);     //set SQW, see: setSquareWave
-  Wire.write((byte)0x0);     //timer off
-  Wire.endTransmission();
-
+    Wire.write((byte)0x0);     //control/status1
+    Wire.write((byte)0x0);     //control/status2
+    Wire.write((byte)0x81);     //set seconds & VL
+    Wire.write((byte)0x01);    //set minutes
+    Wire.write((byte)0x01);    //set hour
+    Wire.write((byte)0x01);    //set day
+    Wire.write((byte)0x01);    //set weekday
+    Wire.write((byte)0x01);     //set month, century to 1
+    Wire.write((byte)0x01);    //set year to 99
+    Wire.write((byte)0x80);    //minute alarm value reset to 00
+    Wire.write((byte)0x80);    //hour alarm value reset to 00
+    Wire.write((byte)0x80);    //day alarm value reset to 00
+    Wire.write((byte)0x80);    //weekday alarm value reset to 00
+    Wire.write((byte)0x0);     //set SQW, see: setSquareWave
+    Wire.write((byte)0x0);     //timer off
+    Wire.endTransmission();
 }
 
 /* Private internal functions, but useful to look at if you need a similar func. */
 byte Rtc_Pcf8563::decToBcd(byte val)
 {
-  return ( (val/10*16) + (val%10) );
+    return ( (val/10*16) + (val%10) );
 }
 
 byte Rtc_Pcf8563::bcdToDec(byte val)
 {
-  return ( (val/16*10) + (val%16) );
+    return ( (val/16*10) + (val%16) );
 }
 
 
 void Rtc_Pcf8563::clearStatus()
 {
-  Wire.beginTransmission(Rtcc_Addr);    // Issue I2C start signal
-  Wire.write((byte)0x0);
-  Wire.write((byte)0x0);                 //control/status1
-  Wire.write((byte)0x0);                 //control/status2
-  Wire.endTransmission();
+    Wire.beginTransmission(Rtcc_Addr);    // Issue I2C start signal
+    Wire.write((byte)0x0);
+    Wire.write((byte)0x0);                 //control/status1
+    Wire.write((byte)0x0);                 //control/status2
+    Wire.endTransmission();
 }
 
 void Rtc_Pcf8563::setTime(byte hour, byte minute, byte sec)
 {
-  Wire.beginTransmission(Rtcc_Addr);    // Issue I2C start signal
-  Wire.write((byte)RTCC_SEC_ADDR);       // send addr low byte, req'd
+    Wire.beginTransmission(Rtcc_Addr);    // Issue I2C start signal
+    Wire.write((byte)RTCC_SEC_ADDR);       // send addr low byte, req'd
 
-  Wire.write((byte)decToBcd(sec));         //set seconds
-  Wire.write((byte)decToBcd(minute));    //set minutes
-  Wire.write((byte)decToBcd(hour));        //set hour
-  Wire.endTransmission();
-
+    Wire.write((byte)decToBcd(sec));         //set seconds
+    Wire.write((byte)decToBcd(minute));    //set minutes
+    Wire.write((byte)decToBcd(hour));        //set hour
+    Wire.endTransmission();
 }
 
 void Rtc_Pcf8563::setDate(byte day, byte weekday, byte mon, byte century, byte year)
@@ -213,7 +212,7 @@ void Rtc_Pcf8563::setAlarm(byte min, byte hour, byte day, byte weekday)
     Wire.beginTransmission(Rtcc_Addr);    // Issue I2C start signal
     Wire.write((byte)RTCC_ALRM_MIN_ADDR);
     Wire.write((byte)min);                //minute alarm value reset to 00
-    Wire.write((byte)hour);                //hour alarm value reset to 00
+    Wire.write((byte)hour);               //hour alarm value reset to 00
     Wire.write((byte)day);                //day alarm value reset to 00
     Wire.write((byte)weekday);            //weekday alarm value reset to 00
     Wire.endTransmission();
@@ -322,7 +321,6 @@ void Rtc_Pcf8563::getDate()
     //0x1f = 0b00011111
     month = month & 0x1f;
     month = bcdToDec(month);
-year = bcdToDec(Wire.read());
 }
 
 void Rtc_Pcf8563::getTime()

--- a/Rtc_Pcf8563.h
+++ b/Rtc_Pcf8563.h
@@ -1,21 +1,28 @@
 /*****
  *  NAME
- *    External Real Time Clock support routines
+ *    Pcf8563 Real Time Clock support routines
  *  AUTHOR
  *    Joe Robertson, jmr
  *    orbitalair@bellsouth.net
  *    http://orbitalair.wikispaces.com/Arduino
  *  CREATION DATE
- *    1/2/10,  init - built off of pic rtc code
+ *    9/24/06,  init - built off of usart demo.  using mikroC
  *  NOTES
  *  HISTORY
+ *    10/14/06 ported to CCS compiler, jmr
+ *    2/21/09  changed all return values to hex val and not bcd, jmr
+ *    1/10/10  ported to arduino, jmr
+ *    2/14/10  added 3 world date formats, jmr
  *    28/02/2012 A. Pasotti
- *            fixed a bug in RTCC_ALARM_AF,
- *            added a few (not really useful) methods
- *    1/2/10  ported to arduino compiler, jmr
- *    2/14/10 added 3 world date formats, jmr
- *  TODO
+ *             fixed a bug in RTCC_ALARM_AF,
+ *             added a few (not really useful) methods
+ *    22/10/2014 Fix whitespace, tabs, and newlines, cevich
  *
+ *  TODO
+ *    x Add Euro date format
+ *    Add short time (hh:mm) format
+ *    Add 24h/12h format
+ *    Add timer support
  ******
  *  Robodoc embedded documentation.
  *  http://www.xs4all.nl/~rfsber/Robo/robodoc.html
@@ -29,49 +36,49 @@
 
 /* the read and write values for pcf8563 rtcc */
 /* these are adjusted for arduino */
-#define RTCC_R 	0xa3
-#define RTCC_W 	0xa2
+#define RTCC_R      0xa3
+#define RTCC_W      0xa2
 
-#define RTCC_SEC 			1
-#define RTCC_MIN 			2
-#define RTCC_HR 			3
-#define RTCC_DAY 			4
-#define RTCC_WEEKDAY	5
-#define RTCC_MONTH 		6
-#define RTCC_YEAR 		7
-#define RTCC_CENTURY 	8
+#define RTCC_SEC        1
+#define RTCC_MIN        2
+#define RTCC_HR         3
+#define RTCC_DAY        4
+#define RTCC_WEEKDAY    5
+#define RTCC_MONTH      6
+#define RTCC_YEAR       7
+#define RTCC_CENTURY    8
 
 /* register addresses in the rtc */
-#define RTCC_STAT1_ADDR			0x0
-#define RTCC_STAT2_ADDR			0x01
-#define RTCC_SEC_ADDR  			0x02
-#define RTCC_MIN_ADDR 			0x03
-#define RTCC_HR_ADDR 			0x04
-#define RTCC_DAY_ADDR 			0x05
-#define RTCC_WEEKDAY_ADDR		0x06
-#define RTCC_MONTH_ADDR 		0x07
-#define RTCC_YEAR_ADDR 			0x08
-#define RTCC_ALRM_MIN_ADDR 	    0x09
-#define RTCC_SQW_ADDR 	        0x0D
+#define RTCC_STAT1_ADDR     0x0
+#define RTCC_STAT2_ADDR     0x01
+#define RTCC_SEC_ADDR       0x02
+#define RTCC_MIN_ADDR       0x03
+#define RTCC_HR_ADDR        0x04
+#define RTCC_DAY_ADDR       0x05
+#define RTCC_WEEKDAY_ADDR   0x06
+#define RTCC_MONTH_ADDR     0x07
+#define RTCC_YEAR_ADDR      0x08
+#define RTCC_ALRM_MIN_ADDR  0x09
+#define RTCC_SQW_ADDR       0x0D
 
 /* setting the alarm flag to 0 enables the alarm.
  * set it to 1 to disable the alarm for that value.
  */
-#define RTCC_ALARM				0x80
-#define RTCC_ALARM_AIE 			0x02
-#define RTCC_ALARM_AF 			0x08 // 0x08 : not 0x04!!!!
+#define RTCC_ALARM      0x80
+#define RTCC_ALARM_AIE  0x02
+#define RTCC_ALARM_AF   0x08 // 0x08 : not 0x04!!!!
 /* optional val for no alarm setting */
-#define RTCC_NO_ALARM				99
+#define RTCC_NO_ALARM   99
 
-#define RTCC_CENTURY_MASK 	0x80
+#define RTCC_CENTURY_MASK   0x80
 
 /* date format flags */
-#define RTCC_DATE_WORLD			0x01
-#define RTCC_DATE_ASIA			0x02
-#define RTCC_DATE_US				0x04
+#define RTCC_DATE_WORLD     0x01
+#define RTCC_DATE_ASIA      0x02
+#define RTCC_DATE_US        0x04
 /* time format flags */
-#define RTCC_TIME_HMS				0x01
-#define RTCC_TIME_HM				0x02
+#define RTCC_TIME_HMS       0x01
+#define RTCC_TIME_HM        0x02
 
 /* square wave contants */
 #define SQW_DISABLE     B00000000
@@ -83,74 +90,75 @@
 
 /* arduino class */
 class Rtc_Pcf8563 {
-	public:
-		Rtc_Pcf8563();
+    public:
+    Rtc_Pcf8563();
 
-		void initClock();		/* zero out all values, disable all alarms */
-		void clearStatus();	/* set both status bytes to zero */
+    void initClock();  /* zero out all values, disable all alarms */
+    void clearStatus(); /* set both status bytes to zero */
 
-		void getDate();			/* get date vals to local vars */
-		void setDate(byte day, byte weekday, byte month, byte century, byte year);
-		void getTime();    /* get time vars + 2 status bytes to local vars */
-		void getAlarm();
-		void setTime(byte hour, byte minute, byte sec);
-		byte readStatus2();
-		boolean alarmEnabled();
-        boolean alarmActive();
+    void getDate();   /* get date vals to local vars */
+    void setDate(byte day, byte weekday, byte month, byte century, byte year);
+    void getTime();    /* get time vars + 2 status bytes to local vars */
+    void setTime(byte hour, byte minute, byte sec, bool volt_low=0);
+    void getAlarm();
+    byte readStatus2();
+    boolean alarmEnabled();
+    boolean alarmActive();
 
-        void enableAlarm(); /* activate alarm flag and interrupt */
-		void setAlarm(byte min, byte hour, byte day, byte weekday); /* set alarm vals, 99=ignore */
-		void clearAlarm();	/* clear alarm flag and interrupt */
-		void resetAlarm();  /* clear alarm flag but leave interrupt unchanged */
-		void setSquareWave(byte frequency);
-		void clearSquareWave();
+    void enableAlarm(); /* activate alarm flag and interrupt */
+    /* set alarm vals, 99=ignore */
+    void setAlarm(byte min, byte hour, byte day, byte weekday);
+    void clearAlarm(); /* clear alarm flag and interrupt */
+    void resetAlarm();  /* clear alarm flag but leave interrupt unchanged */
+    void setSquareWave(byte frequency);
+    void clearSquareWave();
 
-		byte getSecond();
-		byte getMinute();
-		byte getHour();
-		byte getDay();
-		byte getMonth();
-		byte getYear();
-		byte getWeekday();
-		byte getStatus1();
-		byte getStatus2();
+    byte getSecond();
+    byte getMinute();
+    byte getHour();
+    byte getDay();
+    byte getMonth();
+    byte getYear();
+    byte getWeekday();
+    byte getStatus1();
+    byte getStatus2();
 
-		byte getAlarmMinute();
-		byte getAlarmHour();
-		byte getAlarmDay();
-		byte getAlarmWeekday();
+    byte getAlarmMinute();
+    byte getAlarmHour();
+    byte getAlarmDay();
+    byte getAlarmWeekday();
 
-		/*get a output string, these call getTime/getDate for latest vals */
-		char *formatTime(byte style=RTCC_TIME_HMS);
-		/* date supports 3 styles as listed in the wikipedia page about world date/time. */
-		char *formatDate(byte style=RTCC_DATE_US);
+    /*get a output string, these call getTime/getDate for latest vals */
+    char *formatTime(byte style=RTCC_TIME_HMS);
+    /* date supports 3 styles as listed in the wikipedia page about world date/time. */
+    char *formatDate(byte style=RTCC_DATE_US);
 
-	private:
-		/* methods */
-		byte decToBcd(byte value);
-		byte bcdToDec(byte value);
-		/* time variables */
-		byte hour;
-		byte minute;
-		byte sec;
-		byte day;
-		byte weekday;
-		byte month;
-		byte year;
-		/* alarm */
-		byte alarm_hour;
-		byte alarm_minute;
-		byte alarm_weekday;
-		byte alarm_day;
-		/* support */
-		byte status1;
-		byte status2;
-		byte century;
+    private:
+    /* methods */
+    byte decToBcd(byte value);
+    byte bcdToDec(byte value);
+    /* time variables */
+    byte hour;
+    byte minute;
+    byte sec;
+    byte day;
+    byte weekday;
+    byte month;
+    byte year;
+    /* alarm */
+    byte alarm_hour;
+    byte alarm_minute;
+    byte alarm_weekday;
+    byte alarm_day;
+    /* support */
+    byte status1;
+    byte status2;
+    byte century;
 
-		char strOut[9];
-		char strDate[11];
+    char strOut[9];
+    char strDate[11];
 
-		int Rtcc_Addr;
+    int Rtcc_Addr;
 };
 
 #endif

--- a/keywords.txt
+++ b/keywords.txt
@@ -1,36 +1,37 @@
 #######################################
 # Syntax Coloring Map For Rtc_Pcf8563
-####################################### 
+#######################################
 # Datatypes (KEYWORD1)
 #######################################
 
-Rtc_Pcf8563	KEYWORD1
+Rtc_Pcf8563     KEYWORD1
 
 #######################################
 # Methods and Functions (KEYWORD2)
 #######################################
 
-initClock	KEYWORD2
-clearStatus KEYWORD2
-getDate	KEYWORD2
-setDate	KEYWORD2
-getTime	KEYWORD2
-setTime	KEYWORD2
-setAlarm 	KEYWORD2
-clearAlarm	KEYWORD2
-getStatus1	KEYWORD2
-getStatus2	KEYWORD2
-getSecond	KEYWORD2
-getMinute	KEYWORD2
-getHour	KEYWORD2
-getDay	KEYWORD2
-getWeekDay	KEYWORD2
-getMonth	KEYWORD2
-getYear	KEYWORD2
-formatTime	KEYWORD2
-formatDate	KEYWORD2
-	
+initClock       KEYWORD2
+clearStatus     KEYWORD2
+getDateTime     KEYWORD2
+getDate         KEYWORD2
+setDateTime     KEYWORD2
+setDate         KEYWORD2
+getTime         KEYWORD2
+setTime         KEYWORD2
+setAlarm        KEYWORD2
+clearAlarm      KEYWORD2
+getStatus1      KEYWORD2
+getStatus2      KEYWORD2
+getSecond       KEYWORD2
+getMinute       KEYWORD2
+getHour         KEYWORD2
+getDay          KEYWORD2
+getWeekDay      KEYWORD2
+getMonth        KEYWORD2
+getYear         KEYWORD2
+formatTime      KEYWORD2
+formatDate      KEYWORD2
+
 #######################################
 # Constants (LITERAL1)
 #######################################
-


### PR DESCRIPTION
-  Tab characters where mixed with multiple spaces
  leading to editor/IDE dependent presentation.
  Converted all tabs to 4-space characters.  Aligned
  all misaligned columns and code-blocks for consistency.
-  Linefeed characters throughout make for messy
  results when changes made in non-Windows
  environment, dependent on editor/IDE.  Removed
  all linefeeds and windows-centric text formatting.
-  Several places introduced "hidden" whiteapce
  (end of lines, in blank lines, end of file).
  This can result in change-management/diff problems
  and/or sometimes even cause hard-to-find bugs.
  Removed all trailing whitespace.

Signed-off-by: Chris Evich chris-arduino@anonomail.me
