### PR TITLE
Fix setTime decl: Remove volt_low param.

### DIFF
--- a/Rtc_Pcf8563.h
+++ b/Rtc_Pcf8563.h
@@ -99,7 +99,7 @@ class Rtc_Pcf8563 {
     void getDate();   /* get date vals to local vars */
     void setDate(byte day, byte weekday, byte month, byte century, byte year);
     void getTime();    /* get time vars + 2 status bytes to local vars */
-    void setTime(byte hour, byte minute, byte sec, bool volt_low=0);
+    void setTime(byte hour, byte minute, byte sec);
     void getAlarm();
     byte readStatus2();
     boolean alarmEnabled();


### PR DESCRIPTION
This is introduced by another commit and accidentally
crept over.  Set it back the way it was.
