### PR TITLE
Allow customize sda and scl pins 

### DIFF
--- a/Rtc_Pcf8563.cpp
+++ b/Rtc_Pcf8563.cpp
@@ -39,9 +39,9 @@
 #include <Arduino.h>
 #include "Rtc_Pcf8563.h"
 
-Rtc_Pcf8563::Rtc_Pcf8563(void)
+Rtc_Pcf8563::Rtc_Pcf8563(int sdaPin, int sclPin)
 {
-    Wire.begin();
+    Wire.begin(sdaPin, sclPin);
     Rtcc_Addr = RTCC_R>>1;
 }
 

--- a/Rtc_Pcf8563.h
+++ b/Rtc_Pcf8563.h
@@ -125,7 +125,7 @@ extern TwoWire Wire;
 /* arduino class */
 class Rtc_Pcf8563 {
     public:
-    Rtc_Pcf8563();
+    Rtc_Pcf8563(int sdaPin = -1, int sclPin = -1);
 
     void zeroClock();  /* Zero date/time, alarm / timer, default clkout */
     void clearStatus(); /* set both status bytes to zero */


### PR DESCRIPTION
Right now it's impossible to use other pins than Arduino defaults, i.e.: SDA(21), SCL(22) on framework-espressif32.

It could happen that one would need to use other pins.

This is a non-breaking change.