### PR TITLE
Add a constructor to use different pins for SDA/SDL for I2C bus (need…

### DIFF
--- a/Rtc_Pcf8563.cpp
+++ b/Rtc_Pcf8563.cpp
@@ -25,12 +25,11 @@
  *    26/11/2014 Add zeroClock(), initialize to lowest possible
  *               values, cevich
  *    22/10/2014 add timer support, cevich
- *    19/10/2020 add 12h format, add czech date format
  *
  *  TODO
  *    x Add Euro date format
  *    Add short time (hh:mm) format
- *    x Add 24h/12h format - done
+ *    Add 24h/12h format
  ******
  *  Robodoc embedded documentation.
  *  http://www.xs4all.nl/~rfsber/Robo/robodoc.html
@@ -42,6 +41,12 @@
 Rtc_Pcf8563::Rtc_Pcf8563(void)
 {
     Wire.begin();
+    Rtcc_Addr = RTCC_R>>1;
+}
+
+Rtc_Pcf8563::Rtc_Pcf8563(int sdaPin, int sdlPin)
+{
+    Wire.begin(sdaPin, sdlPin);
     Rtcc_Addr = RTCC_R>>1;
 }
 
@@ -133,17 +138,7 @@ void Rtc_Pcf8563::getDateTime(void)
     minute = bcdToDec(readBuffer[3] & 0x7f);
     //0x3f = 0b00111111
     hour = bcdToDec(readBuffer[4] & 0x3f);
-    if(bcdToDec(readBuffer[4] & 0x3f) > 12)
-    {
-        hour12 = bcdToDec(readBuffer[4] & 0x3f) - 12;
-        am = false;
-    }
-    else
-    {
-        hour12 = hour;
-        am = true;
-    }
-    
+
     // date bytes
     //0x3f = 0b00111111
     day = bcdToDec(readBuffer[5] & 0x3f);
@@ -486,39 +481,6 @@ const char *Rtc_Pcf8563::formatTime(byte style)
 {
     getTime();
     switch (style) {
-        case RTCC_TIME_HMS_12:
-            strOut[0] = '0' + (hour12 / 10);
-            strOut[1] = '0' + (hour12 % 10);
-            strOut[2] = ':';
-            strOut[3] = '0' + (minute / 10);
-            strOut[4] = '0' + (minute % 10);
-            strOut[5] = ':';
-            strOut[6] = '0' + (sec / 10);
-            strOut[7] = '0' + (sec % 10);
-            if(am == true){
-                strOut[8] = 'a';
-            }
-            else{
-                strOut[8] = 'p';
-            }
-            strOut[9] = 'm';
-            strOut[10] = '\0';
-            break;
-        case RTCC_TIME_HM_12:
-            strOut[0] = '0' + (hour12 / 10);
-            strOut[1] = '0' + (hour12 % 10);
-            strOut[2] = ':';
-            strOut[3] = '0' + (minute / 10);
-            strOut[4] = '0' + (minute % 10);
-            if(am == true){
-                strOut[5] = 'a';
-            }
-            else{
-                strOut[5] = 'p';
-            }
-            strOut[6] = 'm';
-            strOut[7] = '\0';
-            break;
         case RTCC_TIME_HM:
             strOut[0] = '0' + (hour / 10);
             strOut[1] = '0' + (hour % 10);
@@ -549,25 +511,7 @@ const char *Rtc_Pcf8563::formatDate(byte style)
     getDate();
 
         switch (style) {
-        case RTCC_DATE_CZ:
-            //do the czech style, dd.mm.yyyy
-            strDate[0] = '0' + (day / 10);
-            strDate[1] = '0' + (day % 10);
-            strDate[2] = '.';
-            strDate[3] = '0' + (month / 10);
-            strDate[4] = '0' + (month % 10);
-            strDate[5] = '.';
-            if (century){
-                strDate[6] = '1';
-                strDate[7] = '9';
-            } else {
-                strDate[6] = '2';
-                strDate[7] = '0';
-            }
-            strDate[8] = '0' + (year / 10 );
-            strDate[9] = '0' + (year % 10);
-            strDate[10] = '\0';
-            break;
+
         case RTCC_DATE_ASIA:
             //do the asian style, yyyy-mm-dd
             if (century ){
@@ -617,10 +561,12 @@ const char *Rtc_Pcf8563::formatDate(byte style)
             strDate[3] = '0' + (month / 10);
             strDate[4] = '0' + (month % 10);
             strDate[5] = '-';
+
             if (century){
                 strDate[6] = '1';
                 strDate[7] = '9';
-            } else {
+            }
+            else {
                 strDate[6] = '2';
                 strDate[7] = '0';
             }

--- a/Rtc_Pcf8563.h
+++ b/Rtc_Pcf8563.h
@@ -103,12 +103,9 @@
 #define RTCC_DATE_WORLD     0x01
 #define RTCC_DATE_ASIA      0x02
 #define RTCC_DATE_US        0x04
-#define RTCC_DATE_CZ        0x05
 /* time format flags */
 #define RTCC_TIME_HMS       0x01
 #define RTCC_TIME_HM        0x02
-#define RTCC_TIME_HMS_12    0x03
-#define RTCC_TIME_HM_12     0x04
 
 /* square wave contants */
 #define SQW_DISABLE     B00000000
@@ -126,6 +123,7 @@ extern TwoWire Wire;
 class Rtc_Pcf8563 {
     public:
     Rtc_Pcf8563();
+    Rtc_Pcf8563(int, int); /* Construct using different pins for sda & sdl */
 
     void zeroClock();  /* Zero date/time, alarm / timer, default clkout */
     void clearStatus(); /* set both status bytes to zero */
@@ -206,8 +204,6 @@ class Rtc_Pcf8563 {
     byte bcdToDec(byte value);
     /* time variables */
     byte hour;
-    byte hour12;
-    bool am;
     byte minute;
     bool volt_low;
     byte sec;


### PR DESCRIPTION
Sometime it is required to use different pins for SDA & SDL, especially when updating program for an  IC made by someone else, here is a simple addition of a constructor to change pins used for SDA & SDL with the I2C bus