### PR TITLE
Fix simultaneous alarm & timer bug

### DIFF
--- a/Rtc_Pcf8563.cpp
+++ b/Rtc_Pcf8563.cpp
@@ -251,8 +251,6 @@ void Rtc_Pcf8563::enableAlarm()
     getDateTime();  // operate on current values
     //set status2 AF val to zero
     status2 &= ~RTCC_ALARM_AF;
-    //set TF to 1 masks it from changing, as per data-sheet
-    status2 |= RTCC_TIMER_TF;
     //enable the interrupt
     status2 |= RTCC_ALARM_AIE;
 
@@ -322,8 +320,6 @@ void Rtc_Pcf8563::clearAlarm()
 {
     //set status2 AF val to zero to reset alarm
     status2 &= ~RTCC_ALARM_AF;
-    //set TF to 1 masks it from changing, as per data-sheet
-    status2 |= RTCC_TIMER_TF;
     //turn off the interrupt
     status2 &= ~RTCC_ALARM_AIE;
 
@@ -340,8 +336,6 @@ void Rtc_Pcf8563::resetAlarm()
 {
     //set status2 AF val to zero to reset alarm
     status2 &= ~RTCC_ALARM_AF;
-    //set TF to 1 masks it from changing, as per data-sheet
-    status2 |= RTCC_TIMER_TF;
 
     Wire.beginTransmission(Rtcc_Addr);
     Wire.write((byte)RTCC_STAT2_ADDR);
@@ -374,8 +368,6 @@ void Rtc_Pcf8563::enableTimer(void)
     timer_control |= RTCC_TIMER_TE;
     //set status2 TF val to zero
     status2 &= ~RTCC_TIMER_TF;
-    //set AF to 1 masks it from changing, as per data-sheet
-    status2 |= RTCC_ALARM_AF;
     //enable the interrupt
     status2 |= RTCC_TIMER_TIE;
 
@@ -425,8 +417,6 @@ void Rtc_Pcf8563::clearTimer(void)
     getDateTime();
     //set status2 TF val to zero
     status2 &= ~RTCC_TIMER_TF;
-    //set AF to 1 masks it from changing, as per data-sheet
-    status2 |= RTCC_ALARM_AF;
     //turn off the interrupt
     status2 &= ~RTCC_TIMER_TIE;
     //turn off the timer
@@ -452,8 +442,6 @@ void Rtc_Pcf8563::resetTimer(void)
     getDateTime();
     //set status2 TF val to zero to reset timer
     status2 &= ~RTCC_TIMER_TF;
-    //set AF to 1 masks it from changing, as per data-sheet
-    status2 |= RTCC_ALARM_AF;
 
     Wire.beginTransmission(Rtcc_Addr);
     Wire.write((byte)RTCC_STAT2_ADDR);


### PR DESCRIPTION
The datasheet shows the following:

> **8.3.2.1 Interrupt Output**
**Bits TF and AF:** When an alarm occurs, AF is set to logic 1. Similarly, at the end of a timer countdown, TF is set to logic 1. These bits maintain their value until overwritten using the interface. If both timer and alarm interrupts are required in the application, the source of the interrupt can be determined by reading these bits. To prevent one flag being overwritten while clearing another, a logic AND is performed during a write access.

In the original code, these lines:
```C
//set TF to 1 masks it from changing, as per data-sheet
status2 |= RTCC_TIMER_TF;
```
are added in several places to accomodate these logic ANDs.

However it looks like the logic AND is automatically performed with a 1, and setting the TF/AF to 1 manually like this is interpreted as actually setting the TF/AF to 1. It led to unwanted positive TF/AF flags for me.

Deleting this operation in six places (enable/disable/reset, timer/alarm) led to expected behavior when running both a recurring timer and a one-time alarm.

-RJ